### PR TITLE
fix: centered link text

### DIFF
--- a/src/components/comp/credit-catd.tsx
+++ b/src/components/comp/credit-catd.tsx
@@ -8,7 +8,7 @@ export function CreditCard({ credit }: Props) {
   return (
     <div className="w-full rounded-lg border bg-card text-card-foreground shadow-sm py-2 px-3 text-zinc-500">
       <div className="flex justify-between it">
-        <Link className="hover:underline hover:underline-offset-2" href={credit.twitter || credit.github || ""} rel="noopener noreferrer" target="_blank">
+        <Link className="flex items-center hover:underline hover:underline-offset-2" href={credit.twitter || credit.github || ""} rel="noopener noreferrer" target="_blank">
           @{credit.author}
         </Link>
         <div className="flex space-x-4">


### PR DESCRIPTION
Centers the text of the author links vertically.

| Before | After |
| - | - |
| ![Screenshot 2024-04-23 at 15 46 14 (Arc)](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/47499684/86d7bca0-be81-4151-b43d-e0de3dbd2bdc) | ![Screenshot 2024-04-23 at 15 47 03 (Arc)](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/47499684/fc75f6cb-3a68-487b-8aa0-35cb9d00ae40) |