### PR TITLE
Fix logo index icons

### DIFF
--- a/src/components/comp/brand-card.tsx
+++ b/src/components/comp/brand-card.tsx
@@ -23,7 +23,7 @@ export function BrandCard({ brand }: BrandCardProps) {
   };
 
   return (
-    <Card className="w-full card-container">
+    <Card className="w-full grid grid-rows-card card-container">
       <CardHeader>
         <CardTitle>{brand.name}</CardTitle>
       </CardHeader>
@@ -39,7 +39,7 @@ export function BrandCard({ brand }: BrandCardProps) {
             }}
           />
         </div>
-        <div className="flex flex-wrap justify-start w-full gap-2">
+        <div className="flex flex-wrap justify-start w-full !mt-auto gap-2">
           {brand.logos.map((logo, index) => (
             <Button
               key={index}

--- a/src/components/comp/brand-card.tsx
+++ b/src/components/comp/brand-card.tsx
@@ -39,13 +39,13 @@ export function BrandCard({ brand }: BrandCardProps) {
             }}
           />
         </div>
-        <div className="grid grid-cols-4 gap-2">
+        <div className="flex flex-wrap justify-start w-full gap-2">
           {brand.logos.map((logo, index) => (
             <Button
               key={index}
               variant="outline"
               size="sm"
-              className={cn("rounded-full text-xs min-w-20 h-8 w-full", { "border-zinc-600": currentLogoIndex === index })}
+              className={cn("rounded-full text-xs min-w-20 h-8", { "border-zinc-600": currentLogoIndex === index })}
               onClick={() => setCurrentLogoIndex(index)}
             >
               {logo.type || "default"}

--- a/src/components/comp/credit-card.tsx
+++ b/src/components/comp/credit-card.tsx
@@ -9,7 +9,7 @@ type Props = {
 export function CreditCard({ credit }: Props) {
   return (
     <div className="w-full rounded-lg border bg-card text-muted-foreground shadow-sm py-2 px-3">
-      <div className="flex justify-between it">
+      <div className="flex flex-wrap gap-3 justify-between it">
         <Link className="flex items-center hover:underline hover:underline-offset-2" href={credit.twitter || credit.github || ""} rel="noopener noreferrer" target="_blank">
           @{credit.author}
         </Link>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -67,6 +67,9 @@ const config = {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },
+      gridTemplateRows: {
+        card: "auto 1fr auto",
+      },
     },
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
Fixes the chip icons to not overflow.

For future consideration, you may want to just hide icons which only have the "default" chip, as that doesn't really make sense for selecting things. One possible issue with that is 

## Before

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/24af44fa-2c71-4a7f-ae06-cf0e19408519)


## After

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/37ecb083-eb6a-4967-bbcc-58792908d577)

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/cb0ef0e7-da60-40ab-81f0-bd4dc7d933d3)

## Additional info

This changes the previous `grid` based implementation to use `flex`. A solution like this could also probably be done with `grid`, however flex allows for chips to be different sizes.

Additionally, the direction of the row flow can be adjusted if the `default` text should be at the bottom left or any other location. The spacing can also be adjusted.

> Reversing the chip vertical wrap order
> `flex-wrap-reverse`

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/be2550db-fb8a-4fe4-974b-47740a639d7a)

> Justifying into the center using space around
> `justify-around`

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/ecb7efab-4735-414a-be0e-72e5bb24cbbf)

> Justifying into the center
> `justify-center`

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/056b0f40-7d59-4963-a696-4383fc1edf77)

If any of these seem like they match your vision for the cards, please let me know. I can change them very easily.