### PR TITLE
fix: card margins

### DIFF
--- a/src/components/comp/brand-card.tsx
+++ b/src/components/comp/brand-card.tsx
@@ -28,7 +28,7 @@ export function BrandCard({ brand }: BrandCardProps) {
         <CardTitle>{brand.name}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col justify-center items-center space-y-2">
-        <div className="h-48 md:h-64 relative w-full">
+        <div className="relative mb-auto h-48 w-full md:h-64">
           <Image
             src={currentLogo.url}
             alt={brand.name}
@@ -39,7 +39,7 @@ export function BrandCard({ brand }: BrandCardProps) {
             }}
           />
         </div>
-        <div className="flex flex-wrap justify-start w-full !mt-auto gap-2">
+        <div className="flex flex-wrap justify-start w-full gap-2">
           {brand.logos.map((logo, index) => (
             <Button
               key={index}

--- a/src/components/comp/card-list.tsx
+++ b/src/components/comp/card-list.tsx
@@ -6,7 +6,7 @@ type Props = {
 };
 export function BrandCardList({ brands }: Props) {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="w-full grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {brands.map((brand) => (
         <BrandCard key={brand.name + brand.logos[0].credit.author} brand={brand} />
       ))}


### PR DESCRIPTION
Fixes the margin to keep the minimum. Rookie mistake!

## Before

Previous fix forgot that overriding the top margin... overrides it!

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/d4ab5e35-2085-448e-b04f-353713db897c)

## After

The solution was to put the auto margin on the bottom of the previous element.

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/32a6e9d2-084e-4172-b70f-b01ba8eed1f8)
