### PR TITLE
Fix card widths

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,7 +143,7 @@ export default function Dashboard() {
             </DropdownMenuContent>
           </DropdownMenu> */}
         </header>
-        <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
+        <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6 max-w-screen-2xl">
           <div className="flex items-center">{/* <h1 className="text-lg font-semibold md:text-2xl">Inventory</h1> */}</div>
           <div className="flex flex-1 items-start justify-center rounded-lg border--0 border-dashed shadow-sm" x-chunk="dashboard-02-chunk-1">
             <div className="w-full z-10 items-center justify-between text-sm lg:flex overflow-y-auto">

--- a/src/components/comp/card-list.tsx
+++ b/src/components/comp/card-list.tsx
@@ -6,7 +6,7 @@ type Props = {
 };
 export function BrandCardList({ brands }: Props) {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="w-full grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {brands.map((brand) => (
         <BrandCard key={brand.name + brand.logos[0].credit.author} brand={brand} />
       ))}


### PR DESCRIPTION
Fixes the card widths not fitting when showing less icons. It's inconsistent to trigger, but happens because the width of the card grid is not set to full.

This change makes the card list expand fully and sets a decent maximum size to somewhat emulate the presumed intention of the three column grid. (though that can be adjusted at any time)

To replicate, simply filter to only **murimurikyu** (or other single category) and observe the card width change.

## Before

Cards do not match widths

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/bb2402e5-d422-4c6e-9e95-adf78053b6dd)

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/5f7f9a77-79e8-4cc1-8a52-cf89ed3fa258)

## After

Cards now match widths

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/3fa6d434-363a-46ff-a89b-41e7eeb5e3a0)

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/a3eb4cc2-0b19-43a6-a021-8002063d14ae)

## Additional Info

So as it turns out, the original grid chip setup actually was causing a LOT of spaghetti. Since it was overflowing each of the chips, it was secretly also boosting the width of each card significantly. After changing it to flex, a bunch of other jank things like the card list not being set to `w-max` no longer hand weird children elements which were oversized.

This fix makes it a lot more clear by setting `w-max` and actually setting a maximum width on the `<main>` of the document.

### Version Hisory

Before everything, the chip size shenanigans made it a lot wider:

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/9f8b045f-dcb8-40fa-8980-b6b5318c3793)

After fixing the chips to flow correctly, they started working a bit better in normal sizes but weren't set to grow correctly:

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/267fff21-35ee-41b5-9994-236d60951927)

This fix makes them grow correctly and adds a proper max width to the page:

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/acb6a4ff-3ec5-4079-9ac6-9f2f15ba3a79)

(yes, I wrote a historical note to change like 2 lines)