### PR TITLE
Fix tooltip disappearing

### DIFF
--- a/src/components/comp/credit-card.tsx
+++ b/src/components/comp/credit-card.tsx
@@ -27,7 +27,7 @@ export function CreditCard({ credit }: Props) {
             </Link>
           )}
           {credit.license && (
-            <TooltipProvider>
+            <TooltipProvider delayDuration={50}>
               <Tooltip>
                 <TooltipTrigger asChild ref={triggerRef} onClick={(event) => event.preventDefault()}>
                   <Info className="cursor-pointer" />

--- a/src/components/comp/credit-card.tsx
+++ b/src/components/comp/credit-card.tsx
@@ -1,5 +1,6 @@
 import { ICredit } from "@/data/type";
 import { Github, Info, Twitter } from "lucide-react";
+import { useRef } from "react";
 import Link from "next/link";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -7,6 +8,7 @@ type Props = {
   credit: ICredit;
 };
 export function CreditCard({ credit }: Props) {
+  const triggerRef = useRef(null);
   return (
     <div className="w-full rounded-lg border bg-card text-muted-foreground shadow-sm py-2 px-3">
       <div className="flex flex-wrap gap-3 justify-between it">
@@ -27,12 +29,16 @@ export function CreditCard({ credit }: Props) {
           {credit.license && (
             <TooltipProvider>
               <Tooltip>
-                <TooltipTrigger asChild>
+                <TooltipTrigger asChild ref={triggerRef} onClick={(event) => event.preventDefault()}>
                   <Info className="cursor-pointer" />
                 </TooltipTrigger>
-                <TooltipContent>
-                  <div className="w-40 sm:w-56 flex flex-col justify-start gap-4">
-                    {credit.license.name && <div className="font-bold text-lg">{credit.license.name}</div>}
+                <TooltipContent
+                  onPointerDownOutside={(event) => {
+                    if (event.target === triggerRef.current) event.preventDefault();
+                  }}
+                >
+                  <div className="flex w-40 flex-col justify-start gap-4 sm:w-56">
+                    {credit.license.name && <div className="text-lg font-bold">{credit.license.name}</div>}
                     {credit.license.description && <div className="">{credit.license.description}</div>}
 
                     <Link href={credit.license.url} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Fixes tooltips appearing extremely slowly and disappearing on click. Also changes them to appear faster for a better user experience.

## Before

Hovering takes [700 milliseconds by default](https://www.radix-ui.com/primitives/docs/components/tooltip#root) and hides if users click the info icon:

https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/f72b144b-b252-4b14-80f8-c4c657062472

## After

Hovering now takes 50 milliseconds (adjustable) and persists on click:

https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/2834df64-b3b3-4a04-a2f7-7aed3bdc5825

## Additional Info

The behavior is caused by the intent that [tooltips are used to explain buttons](https://github.com/radix-ui/primitives/issues/2029). As a result, they are supposed to hide on interaction so users can see the button has been pressed.

This solution was taken from a link in that thread as noted as a [user story](https://github.com/radix-ui/primitives/blob/main/packages/react/tooltip/src/Tooltip.stories.tsx#L659-L687).

I made a spelling mistake on my branch's name...