### PR TITLE
Fix sidebar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -93,7 +93,7 @@ export default function Dashboard() {
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="flex flex-col">
-              <div className="md:hidden">
+              <div className="md:hidden w-fit">
                 <Link href="https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection" target="_blank" rel="noopener noreferrer">
                   <Github />
                 </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,7 +52,7 @@ export default function Dashboard() {
   return (
     <div className="grid min-h-screen w-full md:grid-cols-[220px_1fr] lg:grid-cols-[280px_1fr]">
       <div className="hidden border-r bg-muted/40 md:block">
-        <div className="flex h-full max-h-screen flex-col gap-2">
+        <div className="flex h-full flex-col gap-2">
           <div className="flex h-14 items-center border-b px-4 lg:h-[60px] lg:px-6">
             <Link href="/" className="flex items-center gap-2 font-semibold">
               {/* <Package2 className="h-6 w-6" /> */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -93,7 +93,7 @@ export default function Dashboard() {
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="flex flex-col">
-              <div className="sm:hidden">
+              <div className="md:hidden">
                 <Link href="https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection" target="_blank" rel="noopener noreferrer">
                   <Github />
                 </Link>
@@ -121,7 +121,7 @@ export default function Dashboard() {
             </form> */}
             <ToolBar setSearch={setSearch} />
           </div>
-          <div className="hidden sm:block">
+          <div className="hidden md:block">
             <Link href="https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection" target="_blank" rel="noopener noreferrer">
               <Github />
             </Link>


### PR DESCRIPTION
Fixes the sidebar crushing the logo on short screens and GitHub icon not moving over properly.

Also fixes the GitHub icon's hitbox on mobile, changing it to be just the icon instead of the entire width of the sidebar.

## Before

Logo space is crushed:

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/74c02f7e-fd37-4aca-bac5-b76d35e64fd5)

GitHub icon does not move over between `md` and `sm` size:

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/607dc456-246e-44a0-bffb-15b8629924e7)

## After

Logo space is no longer crushed:

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/6fea337a-80a4-4886-9562-ba901e93ea1b)

GitHub icon does not moves over between `md` and `sm` size:

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/a17fa2b0-923c-4208-8d0f-24cd39b99742)

## Additional Info

The logo text issue was caused by `max-h-screen` which made the sorting bar have a maximum height equal to the screen. It would usually not be seen by users with extremely tall screens.

The GitHub logo issue was caused by the criteria for moving over being set to `sm` instead of `md` when the sidebar was showing up at `md` size. It would usually not show up for most users as the specific screen width to appear is uncommon.
