### PR TITLE
feat: darken search on hover

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type,
       autoFocus
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none ring-2 ring-gray-500 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none ring-2 ring-gray-500 disabled:cursor-not-allowed disabled:opacity-50 focus:ring-gray-700",
         className
       )}
       ref={ref}


### PR DESCRIPTION
> [!IMPORTANT]
> **THIS IS MORE OF AN IDEA/SUGGESTION THAN A FIX**

Changes the scrollbar ring to darken slightly when the user is focused on it. This change specifically is very subtle as there isn't much to work with in terms of contrast.

I would also suggest picking a primary color, as it is hard to show emphasis without one. If you do, please close this request and make the ring hover color the new primary color.

## Before

No visible change

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/998e5fba-57b9-4efd-a83d-5b64586713b0)

## After

Slight visible change

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/639f8fb8-3076-4f62-925a-b2e69c53e174)
