### PR TITLE
feat: hide logo types if only default

### DIFF
--- a/src/components/comp/brand-card.tsx
+++ b/src/components/comp/brand-card.tsx
@@ -39,19 +39,21 @@ export function BrandCard({ brand }: BrandCardProps) {
             }}
           />
         </div>
-        <div className="flex flex-wrap justify-start w-full gap-2">
-          {brand.logos.map((logo, index) => (
-            <Button
-              key={index}
-              variant="outline"
-              size="sm"
-              className={cn("rounded-full text-xs min-w-20 h-8", { "border-zinc-600": currentLogoIndex === index })}
-              onClick={() => setCurrentLogoIndex(index)}
-            >
-              {logo.type || "default"}
-            </Button>
-          ))}
-        </div>
+        {brand.logos.length > 1 && (
+          <div className="flex w-full flex-wrap justify-start gap-2">
+            {brand.logos.map((logo, index) => (
+              <Button
+                key={index}
+                variant="outline"
+                size="sm"
+                className={cn("h-8 min-w-20 rounded-full text-xs", { "border-zinc-600": currentLogoIndex === index })}
+                onClick={() => setCurrentLogoIndex(index)}
+              >
+                {logo.type || "default"}
+              </Button>
+            ))}
+          </div>
+        )}
         <CreditCard credit={currentLogo.credit} />
       </CardContent>
       <CardFooter className="flex justify-between">


### PR DESCRIPTION
> [!IMPORTANT]
> **THIS IS MORE OF AN IDEA/SUGGESTION THAN A FIX**

Changes logo type chips to only appear if there is more than one.

This kind of a a stylistic choice, but I believe it makes the page easier to understand since users won't be confused what the default means when no other context is given.

(Also, this technically sorts the contained classes because I had prettier enabled)

## Before

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/07e5990f-e852-437f-b886-8d9312aae1c1)

## After

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/8a9f0797-95b7-4a2f-972e-584302b9ed99)
