### PR TITLE
fix: sidebar not scrolling on mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Dashboard() {
                 <span className="sr-only">Toggle navigation menu</span>
               </Button>
             </SheetTrigger>
-            <SheetContent side="left" className="flex flex-col">
+            <SheetContent side="left" className="flex flex-col overflow-auto">
               <div className="md:hidden w-fit">
                 <Link href="https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection" target="_blank" rel="noopener noreferrer">
                   <Github />


### PR DESCRIPTION
Fixes the sidebar not scrolling on mobile (#30).

## Before

![Peek 2024-05-25 17-01](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/5f9f183f-400a-4fd8-8334-640b72876795)

## After

![Peek 2024-05-25 17-02](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/55a7bc44-1daa-4b79-a05b-afbde51003f0)

## Additional Info

This happened because the element was just flowing off the screen. The element would be so tall it went off screen

![image](https://github.com/Ender-Wiggin2019/VTuber-Logos-Collection/assets/109556932/184f2426-fd11-4d8a-b7d1-c19bbb8b9547)

Technically this also adds a slightly ugly scrollbar if someone was viewing the page on a 400 pixel wide monitor, but like, that's their problem at that point...