### PR TITLE
ui: make sidebar and header sticky

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,13 +77,13 @@ export default function Dashboard() {
   return (
     <div className="grid min-h-screen w-full md:grid-cols-[220px_1fr] lg:grid-cols-[280px_1fr]">
       <div className="hidden border-r bg-muted/40 md:block">
-        <div className="flex h-full flex-col gap-2">
+        <div className="sticky top-0 flex h-screen flex-col gap-2">
           <div className="flex h-14 items-center border-b px-4 lg:h-[60px] lg:px-6">
             <Link href="/" className="flex items-center gap-2 font-semibold">
               <span className="">VTuber Style Logos</span>
             </Link>
           </div>
-          <div className="flex-1">
+          <div className="flex-1 overflow-y-auto">
             <nav className="grid items-start px-2 text-sm font-medium lg:px-4">
               <FilterContainer onChangeFilter={onChangeFilter} />
             </nav>
@@ -93,7 +93,7 @@ export default function Dashboard() {
         </div>
       </div>
       <div className="flex flex-col">
-        <header className="flex h-14 items-center gap-4 border-b bg-muted/40 px-4 lg:h-[60px] lg:px-6">
+        <header className="sticky top-0 z-20 flex h-14 items-center gap-4 border-b bg-muted/40 px-4 lg:h-[60px] lg:px-6">
           <Sheet>
             <SheetTrigger asChild>
               <Button variant="outline" size="icon" className="shrink-0 md:hidden">


### PR DESCRIPTION
Make desktop sidebar and top header sticky for easier navigation while scrolling.
Because I felt the side scrolling behavior was strange when I was using it.