### PR TITLE
Fix bug: Search box moves downward when scrolling down in Firefox

### DIFF
--- a/src/components/comp/tool-bar.tsx
+++ b/src/components/comp/tool-bar.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export function ToolBar({ setSearch }: Props) {
   return (
-    <div className="fixed flex items-center z-50 space-x-4 h-10 pr-2">
+    <div className="flex items-center z-50 space-x-4 h-10 pr-2">
       <SearchBar setSearch={setSearch} />
       <ToTopButton />
       <DarkModeToggle />


### PR DESCRIPTION
Fix #42

After investigation, the bug was caused by nesting a `fixed` positioned element inside a `relative` positioned element, which leads to rendering errors in Firefox.

**Fix**: Remove the unnecessary `fixed` positioning (the parent `<header>` element already uses `sticky` positioning to stay at the top of the page, so there's no need to set `fixed` positioning for child elements).

This change fixes the bug on Firefox and will not affect behavior on other browsers (has been tested on Chromium).
